### PR TITLE
cms: fix the http 413 problem when saving a "big" blog entry

### DIFF
--- a/cms/src/main/resources/application.properties
+++ b/cms/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 quarkus.http.port=9090
+quarkus.http.limits.max-form-attribute-size=10K
 quarkus.web-bundler.bundle.cms=true
 quarkus.web-bundler.bundle.cms.qute-tags=true
 quarkus.datasource.jdbc.url=jdbc:h2:../db;AUTO_SERVER=TRUE


### PR DESCRIPTION
- add quarkus.http.limits.max-form-attribute-size=10K
- the UI still needs to handle this kind of problem gracefully