### PR TITLE
Blog: show entry abstract on the index page

### DIFF
--- a/blog/src/main/java/web/lab/TemplateExtensions.java
+++ b/blog/src/main/java/web/lab/TemplateExtensions.java
@@ -1,11 +1,13 @@
 package web.lab;
 
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+
 import com.vladsch.flexmark.html.HtmlRenderer;
 import com.vladsch.flexmark.parser.Parser;
 import com.vladsch.flexmark.util.ast.Node;
+
 import io.quarkus.qute.TemplateExtension;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
 
 /**
  * Add your custom Qute extension methods here.
@@ -13,16 +15,16 @@ import org.jsoup.nodes.Document;
 @TemplateExtension
 public class TemplateExtensions {
 
+    private static final Parser PARSER = Parser.builder().build();
+    private static final HtmlRenderer RENDERER = HtmlRenderer.builder().build();
 
     public static String mdToHtml(String string) {
-        Parser parser = Parser.builder().build();
-        Node document = parser.parse(string);
-        HtmlRenderer renderer = HtmlRenderer.builder().build();
-        return renderer.render(document);
+        Node document = PARSER.parse(string);
+        return RENDERER.render(document);
     }
 
-    public static String toAbstract(String string) {
-        Document doc = Jsoup.parse(string);
+    public static String toAbstract(BlogEntry entry) {
+        Document doc = Jsoup.parse(mdToHtml(entry.content));
         String text = doc.body().text();
         return text.length() > 150 ? text.substring(0, 150) + "..." : text;
     }

--- a/blog/src/main/resources/templates/pub/index.html
+++ b/blog/src/main/resources/templates/pub/index.html
@@ -3,7 +3,8 @@
 <h1>Welcome to my Blog</h1>
 {#for entry in BlogEntry:listAllSortedByCreated}
 <article>
-<h2><a href="/blog/{entry.slug}">{entry.title}</a></h2>
+  <h2><a href="/blog/{entry.slug}">{entry.title}</a></h2>
+  <p>{entry.toAbstract}</p>
   <a href="/blog/{entry.slug}">Read more</a>
 </article>
 {/for}


### PR DESCRIPTION
- also cache flexmark parser and renderer; I'm not 100% sure they're thread-safe but at least they use it like this in an example in the readme: https://github.com/vsch/flexmark-java?tab=readme-ov-file#pegdown-migration-helper